### PR TITLE
Set scope to tagged collections and institutions

### DIFF
--- a/_includes/js/config.js
+++ b/_includes/js/config.js
@@ -152,7 +152,7 @@ var siteConfig = {
       "recordedBy",
       "identifiedBy"
     ],
-    
+
     "mapSettings": {
       "lat": 0,
       "lng": 0,
@@ -162,7 +162,7 @@ var siteConfig = {
   "collectionSearch": {
     "scope": {
       "displayOnNHCPortal": true,
-      "country": "US"
+      "machineTagNamespace": "iDigBio.org"
     },
     "excludedFilters": [
       "countrySingleGrSciColl"
@@ -171,7 +171,7 @@ var siteConfig = {
   "institutionSearch": {
     "scope": {
       "displayOnNHCPortal": true,
-      "country": "US"
+      "machineTagNamespace": "iDigBio.org"
     },
     "excludedFilters": [
       "country"


### PR DESCRIPTION
We've implemented the filter for the tagged collections and institutions, this PR changes the scope of the portal to use it.

