### PR TITLE
Change the occurrence scope to the new iDigBio network in the GBIF registry

### DIFF
--- a/_includes/js/config.js
+++ b/_includes/js/config.js
@@ -4,6 +4,8 @@ var siteTheme = gbifReactComponents.themeBuilder.extend({
   }
 });
 
+const iDigBioNetworkKey = '68e8e67a-43e6-44a3-8817-dc0e6b70f973';
+
 var siteConfig = {
   "version": 3,
   "pages": [
@@ -85,37 +87,9 @@ var siteConfig = {
   },
   "occurrenceSearch": {
     "scope": {
-      "type": "and",
-      "predicates": [
-        {
-          "type": "or",
-          "predicates": [
-            {
-              "type": "isNotNull",
-              "key": "institutionKey"
-            },
-            {
-              "type": "isNotNull",
-              "key": "collectionKey"
-            }
-          ]
-        },
-        {
-          "type": "in",
-          "key": "basisOfRecord",
-          "values": [
-            "PRESERVED_SPECIMEN",
-            "FOSSIL_SPECIMEN",
-            "MATERIAL_SAMPLE",
-            "LIVING_SPECIMEN"
-          ]
-        },
-        {
-          "type": "equals",
-          "key": "publishingCountry",
-          "value": "US"
-        }
-      ]
+      "type": "equals",
+      "key": "networkKey",
+      "value": iDigBioNetworkKey
     },
     "tabs": [
       "table",


### PR DESCRIPTION
This uses the new network: https://registry.gbif.org/network/68e8e67a-43e6-44a3-8817-dc0e6b70f973/constituents or https://www.gbif.org/occurrence/search?advanced=1&network_key=68e8e67a-43e6-44a3-8817-dc0e6b70f973

It also removes the limitation to specimen basisOfRecord values since a couple of datasets have 'OCCURRENCE' as the BoR: https://www.gbif.org/occurrence/search?basis_of_record=HUMAN_OBSERVATION&basis_of_record=OCCURRENCE&advanced=1&network_key=68e8e67a-43e6-44a3-8817-dc0e6b70f973 — of course the restriction can be added if you want it.

I've also removed publishingCountry=US, since this would be PR for [this dataset](https://www.gbif.org/dataset/43e54c60-d6e0-41df-80a3-ca9487a3342a) (if in scope) anyway, and potentially AS, MP, GU, VI, UM in the future, and in any case it's redundant when the datasets are specified in a network.